### PR TITLE
log full exceptions in GUMSXACMLMappingServiceImpl

### DIFF
--- a/gums-service/src/main/java/gov/bnl/gums/service/GUMSXACMLMappingServiceImpl.java
+++ b/gums-service/src/main/java/gov/bnl/gums/service/GUMSXACMLMappingServiceImpl.java
@@ -144,7 +144,7 @@ public class GUMSXACMLMappingServiceImpl implements XACMLMappingService {
 			}
 		} catch (Exception e1) {
 			statusCode.setValue(ERROR);
-			log.debug(e1.getMessage(), e1);
+			log.debug("Unhandled exception.", e1);
 			throw e1;
 		}
 
@@ -211,7 +211,7 @@ public class GUMSXACMLMappingServiceImpl implements XACMLMappingService {
 			return xacmlAuthzStatement;
 		} catch (Exception e1) {
 			statusCode.setValue(ERROR);
-			log.debug(e1.getMessage());
+			log.debug("Unhandled exception.", e1);
 			throw e1;
 		}
 	}


### PR DESCRIPTION
This is a small improvement for https://jira.opensciencegrid.org/browse/SOFTWARE-1576,
it brings in the full stack trace where it's getting discarded now.