### PR TITLE
don't keep the config object with the insertTest

### DIFF
--- a/gums-core/src/main/java/gov/bnl/gums/configuration/Configuration.java
+++ b/gums-core/src/main/java/gov/bnl/gums/configuration/Configuration.java
@@ -579,7 +579,7 @@ public class Configuration {
 			out.write("\t</hostToGroupMappings>\n\n");
 		}                
 
-		out.write("</gums>");   	
+		out.write("</gums>\n");
     }
 	 
     public void mergeConfiguration(Configuration configuraton, String persistenceFactory, String hostToGroupMapping) {

--- a/gums-core/src/main/java/gov/bnl/gums/configuration/FileConfigurationStore.java
+++ b/gums-core/src/main/java/gov/bnl/gums/configuration/FileConfigurationStore.java
@@ -241,7 +241,8 @@ public class FileConfigurationStore extends ConfigurationStore {
 				int ch;
 				while ((ch = fileInputStream.read()) != -1)
 					configBuffer.append((char)ch);
-				this.conf = ConfigurationToolkit.parseConfiguration(configBuffer.toString(), true);
+				ConfigurationToolkit.parseConfiguration(configBuffer.toString(), true);
+				this.conf = ConfigurationToolkit.parseConfiguration(configBuffer.toString(), false);
 				curModification = new Date(new File(configPath).lastModified());
 			} catch (Exception e) {
 				throw new RuntimeException(e.getMessage(), e);


### PR DESCRIPTION
in case the insertTest is actually useful, still perform it on the reloaded config file, but don't run the insertTest on the config object we actually update, otherwise we end up with "gums-test" and "_test" items inserted into the new gums.config file.