### PR TITLE
Handle null objects correctly

### DIFF
--- a/gums-core/src/main/java/gov/bnl/gums/admin/GUMSAPIImpl.java
+++ b/gums-core/src/main/java/gov/bnl/gums/admin/GUMSAPIImpl.java
@@ -560,6 +560,8 @@ public class GUMSAPIImpl implements GUMSAPI {
 				}
 				else
 					gumsAdminLog.info(logUserAccess() + "Mapped on host '" + hostname + "' the user '" + userDN + "' / '" + fqan + "' to '" + account + "'");
+				// CacheLoader will refuse to cache null objects.  Below will create an account mapped to a null user, which the mapping will handle correctly.
+				if (account == null) {account = new AccountInfo();}
 				return account;
 			} else {
 				String message = logUserAccess() + "Unauthorized access to mapUser for '" + hostname + "' from user '" + userDN + "' / '" + fqan + "'";

--- a/gums-service/src/main/java/gov/bnl/gums/service/GUMSXACMLMappingServiceImpl.java
+++ b/gums-service/src/main/java/gov/bnl/gums/service/GUMSXACMLMappingServiceImpl.java
@@ -66,7 +66,7 @@ public class GUMSXACMLMappingServiceImpl implements XACMLMappingService {
 		String userFqan = getSubjectAttributeValue(request, XACMLConstants.SUBJECT_VOMS_PRIMARY_FQAN_ID);
 
 		String fqanIssuer = getSubjectAttributeIssuerValue(request, XACMLConstants.SUBJECT_VOMS_PRIMARY_FQAN_ID);
-		if (fqanIssuer.equals(NOT_VERIFIED)) {fqanIssuer = null;}
+		if ((fqanIssuer != null) && fqanIssuer.equals(NOT_VERIFIED)) {fqanIssuer = null;}
 		
 		String hostDn = getResourceAttributeValue(request, XACMLConstants.RESOURCE_X509_ID);
 		if (hostDn==null || hostDn.length()==0) {


### PR DESCRIPTION
- Google CacheLoader cannot handle a null object.
- If no FQAN is present, do not cause a NPE on checking its value.