### PR TITLE
Handle a null fqan in VOMSUserGroup objects (SOFTWARE-2035)

### DIFF
--- a/gums-core/src/main/java/gov/bnl/gums/userGroup/VOMSUserGroup.java
+++ b/gums-core/src/main/java/gov/bnl/gums/userGroup/VOMSUserGroup.java
@@ -206,6 +206,12 @@ public class VOMSUserGroup extends UserGroup {
 
     @Override
     public boolean isInGroup(GridUser user) {
+        if (fqan == null) {
+            log.error("FQAN missing for VOMS User Group '" + getName() +
+                      "' (this indicates a missing 'voGroup' attribute in gums.config).");
+            return false;
+        }
+
     	if (user.getVoFQAN() == null) {
             // If the user comes in without FQAN and we don't accept proxies without fqan,
             // kick him out right away


### PR DESCRIPTION
We log an error and return false for isInGroup(), instead of causing an
unhandled NullPointerException later on.

Later we also want to limit the number of times the error gets logged,
rather than for every mapping.