### PR TITLE
Require a username to be set for a mapping result to be accepted.

### DIFF
--- a/gums-core/src/main/java/gov/bnl/gums/CoreLogic.java
+++ b/gums-core/src/main/java/gov/bnl/gums/CoreLogic.java
@@ -425,7 +425,9 @@ public class CoreLogic {
                     while (accountMappersIt.hasNext()) {
                     	AccountMapper accountMapper = (AccountMapper) conf.getAccountMapper( (String)accountMappersIt.next() );
                         AccountInfo localUser = accountMapper.mapUser(user, true);
-                        if (localUser != null)
+                        // Require that an account mapper at least sets the user name in order to use it.
+                        // Replicates the logic in 1.3.x series.
+                        if ((localUser != null) && (localUser.getUser() != null))
                             return localUser;
                     }
                 } else if (gumsAdminLog.isDebugEnabled()) {


### PR DESCRIPTION
Previously (1.3.x), if a user group matched but no account could be
mapped, then the GUMS mapping logic would proceed to the next user
group.  After the refactoring in 1.4.0, the core logic would return
null immediately.

This commit restores the logic found in 1.3.x.

Issue reported by Max @ MIT.