### PR TITLE
Modify setup scripts to allow for a remote MySQL server

### DIFF
--- a/gums-core/src/main/scripts/gums-setup-mysql-database
+++ b/gums-core/src/main/scripts/gums-setup-mysql-database
@@ -88,14 +88,17 @@ fi
 # Construct MySQL parameters
 #
 #-------------------------------------------
+SERVER_WO_PORT=`echo $SERVER | awk -F: '{ print $1 }'`
+SERVER_PORT=`echo $SERVER | awk -F: '{ print $2 }'`
+
 if [ "$PROMPT" -eq 1 ]
 then
-	MYSQLPARAM="-u root -p"
+	MYSQLPARAM="-u root -p -h $SERVER_WO_PORT -P $SERVER_PORT"
 else
 	# When the root doesn't have a password
 	# (like in the VDT setup), -u root doesn't
 	# cause a prompt.
-	MYSQLPARAM="-u root"
+	MYSQLPARAM="-u root -h $SERVER_WO_PORT -P $SERVER_PORT"
 fi
 
 if [ -n "$SOCKET" ]
@@ -135,7 +138,6 @@ then
 	echo Enter the root mysql password
 fi
 
-SERVER_WO_PORT=`echo $SERVER | awk -F: '{ print $1 }'`
 cat /usr/lib/gums/sql/setupDatabase.mysql       \
   | sed -e s/@USER@/$USER/g         \
              -e s/@SERVER@/$SERVER_WO_PORT/g     \


### PR DESCRIPTION
Moved the $SERVER_WO_PORT variable up into the area where MySQL 
parameters are constructed, and created a new variable called $SERVER_PORT 
to separate out the port.

In my use case, I'd like to set up GUMS with the MySQL database living on
another machine. This seemed to be the best way to handle that without
significantly breaking the existing setup script.

Also relevant, from the MySQL 5.1 reference:
"For connections to localhost, MySQL programs attempt to connect to the local
server by using a Unix socket file.  This occurs even if a --port or -P option
is given to specify a port number. To ensure that the client makes a TCP/IP
connection to the local server, use --host or -h to specify a host name value of
127.0.0.1, or the IP address or name of the local server."
https://dev.mysql.com/doc/refman/5.1/en/connecting.html

I take this to mean that specifying -h and -p won't break connections to
localhost.
