### PR TITLE
TYPE changed to ENGINE

### DIFF
--- a/gums-core/src/main/sql/setupDatabase.mysql
+++ b/gums-core/src/main/sql/setupDatabase.mysql
@@ -14,7 +14,7 @@ CREATE TABLE `USERS` (
  `DN` varchar(255) NOT NULL,
  `FQAN` varchar(255) default NULL,
  `EMAIL` varchar(255) default NULL 
-) TYPE=InnoDB;
+) ENGINE=InnoDB;
 
 CREATE INDEX complete ON USERS (GROUP_NAME(10), DN(70), FQAN(30));
 
@@ -25,7 +25,7 @@ CREATE TABLE `MAPPING` (
  `MAP` VARCHAR(255) NOT NULL,
  `DN` varchar(255) default NULL,
  `ACCOUNT` varchar(255) default NULL
-) TYPE=InnoDB;
+) ENGINE=InnoDB;
 
 CREATE UNIQUE INDEX complete ON MAPPING (MAP(10), DN(70));
 
@@ -36,7 +36,7 @@ CREATE TABLE `CONFIG` (
  `CURRENT` BOOL NOT NULL,
  `NAME` varchar(255),
  `AUTOGEN` BOOL NOT NULL DEFAULT 0
-) TYPE=InnoDB;
+) ENGINE=InnoDB;
 
 CREATE INDEX complete ON CONFIG (CURRENT, TIMESTAMP);
 


### PR DESCRIPTION
TYPE has been deprecated since MySQL 4.x. EL7 uses MySQL/MariaDB 5.5 which has
finally dropped support for TYPE. It has been replaced by ENGINE.
